### PR TITLE
[112040] Fixed new plugin issue with pull requests

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
 	"name": "bugzilla-github-extension",
 	"short_name": "BZ<->GH",
 	"description": "This extension integrates GitHub and Bugzilla",
-	"version": "1.14.7",
+	"version": "1.14.8",
 	"background": {
 		"scripts": ["src/background.js"]
 	},

--- a/src/content-script.js
+++ b/src/content-script.js
@@ -153,7 +153,7 @@ function run(settings) {
 			switch (message.method) {				
 				/* Puts Bugzilla bug info into our sidebar section */
 				case "loadBugDetails":
-					setTimeout(loadBugDetails(message), 20);
+					loadBugDetails(message);
 					break;
 				
 				/* Puts Bugzilla bug titles into bug number links */


### PR DESCRIPTION
 Proxied HTMLDivElement.prototype.replaceWith to replace content on the fly. Instead of trying to mess with Ajax responses, I hooked into the prototype for HTMLDivElements and the built-in replaceWith code. Items on pages are now properly replaced by the plugin.
